### PR TITLE
Updated dependencies for version 3.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2024-06-19
+
+### Changed in 3.3.0
+
+- Updated depdendncies to newer versions:
+  - Upgraded `commons-csv` from version `1.10.0` to `1.11.0`
+  - Upgraded `commons-configuration2` from version `2.9.0` to `2.11.0`
+  - Upgraded `icu4j` from version `74.2` to `75.1`
+  - Upgraded `maven-compiler-plugin` from version `3.12.1` to `3.13.0`
+  - Upgraded `maven-surefire-plugin` from version `3.2.5` to `3.3.0`
+  - Upgraded `maven-source-plugin` from version `3.3.0` to `3.3.1`
+  - Upgraded `maven-javadoc-plugin` from version `3.6.3` to `3.7.0`
+  - Upgraded `maven-gpg-plugin` from version `3.1.0` to `3.2.4`
+  - Upgraded `nexus-staging-maven-plugin` from version `1.6.13` to `1.7.0`
+
 ## [3.2.0] - 2024-02-29
 
 ### Changed in 3.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-commons</artifactId>
   <packaging>jar</packaging>
-  <version>3.2.0</version>
+  <version>3.3.0</version>
   <name>Senzing Commons</name>
   <description>Utility classes and functions common to multiple Senzing projects.</description>
   <url>http://github.com/senzing-garage/senzing-commons-java</url>
@@ -51,12 +51,12 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.10.0</version>
+      <version>1.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
-      <version>2.9.0</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.juniversalchardet</groupId>
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>74.2</version>
+      <version>75.1</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -96,7 +96,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.12.1</version>
+        <version>3.13.0</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:unchecked</arg>
@@ -107,7 +107,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.5</version>
+        <version>3.3.0</version>
         <configuration>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
@@ -126,7 +126,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -139,7 +139,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
+        <version>3.7.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -152,7 +152,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -166,7 +166,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.13</version>
+        <version>1.7.0</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>


### PR DESCRIPTION
  - Upgraded `commons-csv` from version `1.10.0` to `1.11.0`
  - Upgraded `commons-configuration2` from version `2.9.0` to `2.11.0`
  - Upgraded `icu4j` from version `74.2` to `75.1`
  - Upgraded `maven-compiler-plugin` from version `3.12.1` to `3.13.0`
  - Upgraded `maven-surefire-plugin` from version `3.2.5` to `3.3.0`
  - Upgraded `maven-source-plugin` from version `3.3.0` to `3.3.1`
  - Upgraded `maven-javadoc-plugin` from version `3.6.3` to `3.7.0`
  - Upgraded `maven-gpg-plugin` from version `3.1.0` to `3.2.4`
  - Upgraded `nexus-staging-maven-plugin` from version `1.6.13` to `1.7.0`