### PR TITLE
Version 3.3.1 with Dependency Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1] - 2024-10-08
+
+### Changed in 3.3.1
+
+- Updated depdendncies to newer versions:
+  - Upgraded `commons-csv` from version `1.11.0` to `1.12.0`
+  - Upgraded `junit-jupiter` from version `5.10.3` to `5.11.2`
+  - Upgraded `maven-surefire-plugin` from version `3.3.0` to `3.5.1`
+  - Upgraded `maven-javadoc-plugin` from version `3.7.0` to `3.10.1`
+  - Upgraded `maven-gpg-plugin` from version `3.2.4` to `3.2.7`
+
 ## [3.3.0] - 2024-06-19
 
 ### Changed in 3.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-commons</artifactId>
   <packaging>jar</packaging>
-  <version>3.3.0</version>
+  <version>3.3.1</version>
   <name>Senzing Commons</name>
   <description>Utility classes and functions common to multiple Senzing projects.</description>
   <url>http://github.com/senzing-garage/senzing-commons-java</url>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.11.0</version>
+      <version>1.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.3</version>
+      <version>5.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -107,7 +107,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.5.1</version>
         <configuration>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
@@ -139,7 +139,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.10.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -152,7 +152,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.7</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>


### PR DESCRIPTION
- Updated depdendncies to newer versions:
  - Upgraded `commons-csv` from version `1.11.0` to `1.12.0`
  - Upgraded `junit-jupiter` from version `5.10.3` to `5.11.2`
  - Upgraded `maven-surefire-plugin` from version `3.3.0` to `3.5.1`
  - Upgraded `maven-javadoc-plugin` from version `3.7.0` to `3.10.1`
  - Upgraded `maven-gpg-plugin` from version `3.2.4` to `3.2.7`