### PR TITLE
#151: Fixed handling of '--ignore-env false' processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-commons</artifactId>
   <packaging>jar</packaging>
-  <version>4.0.0-beta.1.0</version>
+  <version>4.0.0-beta.1.1</version>
   <name>Senzing Commons</name>
   <description>Utility classes and functions common to multiple Senzing projects.</description>
   <url>http://github.com/senzing-garage/senzing-commons-java</url>

--- a/src/main/java/com/senzing/cmdline/CommandLineUtilities.java
+++ b/src/main/java/com/senzing/cmdline/CommandLineUtilities.java
@@ -953,7 +953,7 @@ public class CommandLineUtilities {
     ignoreEnvironment
         = (ignoreEnvironment
           || (result.containsKey(ignoreEnvOption)
-              && (!Boolean.FALSE.equals(result.get(ignoreEnvOption)))));
+              && (!Boolean.FALSE.equals(result.get(ignoreEnvOption).getProcessedValue()))));
     if (!ignoreEnvironment) {
       try {
         processEnvironment(enumClass, processor, result);


### PR DESCRIPTION
Fixed handling of `--ignore-env false` which is an unlikely command-line specification since using the environment is the default.