### PR TITLE
Made the SzInstallLocations class public so it can be used in other projects directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-commons</artifactId>
   <packaging>jar</packaging>
-  <version>4.0.0-beta.1.6</version>
+  <version>4.0.0-beta.2.0</version>
   <name>Senzing Commons</name>
   <description>Utility classes and functions common to multiple Senzing projects.</description>
   <url>http://github.com/senzing-garage/senzing-commons-java</url>

--- a/src/main/java/com/senzing/util/SzInstallLocations.java
+++ b/src/main/java/com/senzing/util/SzInstallLocations.java
@@ -12,7 +12,7 @@ import static com.senzing.util.OperatingSystemFamily.RUNTIME_OS_FAMILY;
  * Describes the directories on disk used to find the Senzing product
  * installation and the support directories.
  */
-class SzInstallLocations {
+public class SzInstallLocations {
     /**
      * The installation location.
      */


### PR DESCRIPTION
I did not want the logic from SzInstallLocations to be duplicated so I made it public 