### PR TITLE
 #202: Release 4.0.0-beta.3.0: add bootstrapSettings() and pre-release version support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0-beta.3.0] - 2026-03-12
+
+### Changed in 4.0.0-beta.3.0
+
+- Added `SzUtilities.bootstrapSettings()` method to build bootstrap JSON
+  settings for Senzing environment initialization without requiring a
+  database URI, enabling access to `SzProduct` functionality.
+- Added null-checks to existing `SzUtilities.basicSettingsFromDatabaseUri()`
+  overloads to fail fast on null URI parameters.
+- Fixed trailing comma in JSON example in `SzUtilities` javadoc.
+- Added pre-release suffix support to `SemanticVersion` for parsing and
+  comparing versions with `-alpha`, `-beta`, and `-rc` suffixes (e.g.:
+  `"2.0.0-alpha.2.0"`, `"2.0.0-beta.3.2"`, `"2.0.0-rc.2.1"`).
+  Pre-release suffixes are normalized to lowercase.
+
 ## [4.0.0-beta.2.1] - 2026-01-29
 
 ### Changed in 4.0.0-beta.2.1

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-commons</artifactId>
   <packaging>jar</packaging>
-  <version>4.0.0-beta.2.1</version>
+  <version>4.0.0-beta.3.0</version>
   <name>Senzing Commons</name>
   <description>Utility classes and functions common to multiple Senzing projects.</description>
   <url>http://github.com/senzing-garage/senzing-commons-java</url>

--- a/src/main/java/com/senzing/util/SemanticVersion.java
+++ b/src/main/java/com/senzing/util/SemanticVersion.java
@@ -75,16 +75,35 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         try {
             String[] tokens = versionString.split("[-.]");
             this.versionParts = new ArrayList<>(tokens.length);
+            boolean hasSuffix = false;
             for (String token : tokens) {
                 switch (token.toLowerCase()) {
                     case "alpha":
-                        this.versionParts.add(ALPHA_VALUE);
-                        break;
                     case "beta":
-                        this.versionParts.add(BETA_VALUE);
-                        break;
                     case "rc":
-                        this.versionParts.add(RC_VALUE);
+                        if (hasSuffix) {
+                            throw new IllegalArgumentException(
+                                    "Multiple pre-release suffixes are not "
+                                    + "allowed: " + versionString);
+                        }
+                        if (this.versionParts.isEmpty()) {
+                            throw new IllegalArgumentException(
+                                    "Pre-release suffix must follow at least "
+                                    + "one numeric version part: "
+                                    + versionString);
+                        }
+                        hasSuffix = true;
+                        switch (token.toLowerCase()) {
+                            case "alpha":
+                                this.versionParts.add(ALPHA_VALUE);
+                                break;
+                            case "beta":
+                                this.versionParts.add(BETA_VALUE);
+                                break;
+                            case "rc":
+                                this.versionParts.add(RC_VALUE);
+                                break;
+                        }
                         break;
                     default:
                         int part = Integer.parseInt(token);
@@ -192,8 +211,8 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
             Integer part1 = iter1.hasNext() ? iter1.next() : 0;
             Integer part2 = iter2.hasNext() ? iter2.next() : 0;
 
-            // get the diff between the parts
-            int diff = part1 - part2;
+            // compare the parts
+            int diff = Integer.compare(part1, part2);
 
             // if the diff is non-zero then return it
             if (diff != 0)

--- a/src/main/java/com/senzing/util/SemanticVersion.java
+++ b/src/main/java/com/senzing/util/SemanticVersion.java
@@ -4,199 +4,257 @@ import java.util.*;
 
 /**
  * Represents a semantic version described as a {@link String} containing
- * integer numbers separated by decimal points (e.g.: "1.4.5").
+ * integer numbers separated by decimal points (e.g.: "1.4.5"), optionally
+ * followed by a pre-release suffix of {@code "-alpha"}, {@code "-beta"},
+ * or {@code "-rc"} with additional dot-separated version parts (e.g.:
+ * "2.0.0-alpha.2.0", "2.0.0-beta.3.2", "2.0.0-rc.2.1").  Pre-release
+ * suffixes are normalized to lowercase on construction (e.g.: {@code "RC"}
+ * becomes {@code "rc"}).
  */
 public class SemanticVersion implements Comparable<SemanticVersion> {
-  /**
-   * The {@link List} of version parts.
-   */
-  private List<Integer> versionParts;
+    /**
+     * The value used to represent a release candidate pre-release suffix.
+     */
+    private static final int RC_VALUE = -1;
 
-  /**
-   * The version string representation.
-   */
-  private String versionString;
+    /**
+     * The value used to represent a beta pre-release suffix.
+     */
+    private static final int BETA_VALUE = -2;
 
-  /**
-   * The normalized version of the {@link String} for calculating the hash code.
-   */
-  private String normalizedString;
+    /**
+     * The value used to represent an alpha pre-release suffix.
+     */
+    private static final int ALPHA_VALUE = -3;
 
-  /**
-   * Constructs with the specified version string (e.g.: "1.4.5").
-   *
-   * @param versionString The version string with which to construct.
-   *
-   * @throws NullPointerException     If the specified parameter is
-   *                                  <code>null</code>.
-   *
-   * @throws IllegalArgumentException If the specified parameter is not properly
-   *                                  formatted.
-   */
-  public SemanticVersion(String versionString)
-      throws NullPointerException, IllegalArgumentException {
-    Objects.requireNonNull(
-        versionString, "Version string cannot be null");
+    /**
+     * An unmodifiable {@link Map} of pre-release integer sentinel values to
+     * their corresponding string suffix representations for use in
+     * reconstructing the version string via {@link #toString()}.
+     */
+    private static final Map<Integer, String> SUFFIX_MAP = Map.of(
+        RC_VALUE,    "-rc",
+        BETA_VALUE,  "-beta",
+        ALPHA_VALUE, "-alpha"
+    );
 
-    try {
-      String[] tokens = versionString.split("\\.");
-      this.versionParts = new ArrayList<>(tokens.length);
-      for (String token : tokens) {
-        int part = Integer.parseInt(token);
-        if (part < 0) {
-          throw new IllegalArgumentException(
-              "Negative version part is not allowed: " + part);
+    /**
+     * The {@link List} of version parts.
+     */
+    private List<Integer> versionParts;
+
+    /**
+     * The version string representation.
+     */
+    private String versionString;
+
+    /**
+     * The normalized version of the {@link String} for calculating the hash code.
+     */
+    private String normalizedString;
+
+    /**
+     * Constructs with the specified version string (e.g.: "1.4.5").
+     * Pre-release suffixes ({@code "alpha"}, {@code "beta"}, {@code "rc"})
+     * are supported and normalized to lowercase (e.g.: {@code "RC"} becomes
+     * {@code "rc"}).
+     *
+     * @param versionString The version string with which to construct.
+     *
+     * @throws NullPointerException     If the specified parameter is
+     *                                  <code>null</code>.
+     *
+     * @throws IllegalArgumentException If the specified parameter is not properly
+     *                                  formatted.
+     */
+    public SemanticVersion(String versionString)
+            throws NullPointerException, IllegalArgumentException {
+        Objects.requireNonNull(
+                versionString, "Version string cannot be null");
+
+        try {
+            String[] tokens = versionString.split("[-.]");
+            this.versionParts = new ArrayList<>(tokens.length);
+            for (String token : tokens) {
+                switch (token.toLowerCase()) {
+                    case "alpha":
+                        this.versionParts.add(ALPHA_VALUE);
+                        break;
+                    case "beta":
+                        this.versionParts.add(BETA_VALUE);
+                        break;
+                    case "rc":
+                        this.versionParts.add(RC_VALUE);
+                        break;
+                    default:
+                        int part = Integer.parseInt(token);
+                        if (part < 0) {
+                            throw new IllegalArgumentException(
+                                    "Negative version part is not allowed: "
+                                    + part);
+                        }
+                        this.versionParts.add(part);
+                        break;
+                }
+            }
+
+            // create a normalized list of version parts by removing trailing zeroes
+            List<Integer> normalized = new LinkedList<>(this.versionParts);
+            Collections.reverse(normalized);
+            Iterator<Integer> iter = normalized.iterator();
+            while (iter.hasNext()) {
+                Integer part = iter.next();
+                if (!part.equals(0))
+                    break;
+                iter.remove();
+            }
+            Collections.reverse(normalized);
+
+            // set the version strings
+            this.versionString = buildVersionString(this.versionParts);
+            this.normalizedString = buildVersionString(normalized);
+
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "Invalid semantic version string: " + versionString);
         }
-        this.versionParts.add(part);
-      }
-
-      // create a normalized list of version parts by removing trailing zeroes
-      List<Integer> normalized = new LinkedList<>(this.versionParts);
-      Collections.reverse(normalized);
-      Iterator<Integer> iter = normalized.iterator();
-      while (iter.hasNext()) {
-        Integer part = iter.next();
-        if (!part.equals(0))
-          break;
-        iter.remove();
-      }
-      Collections.reverse(normalized);
-
-      // set the version strings
-      StringBuilder versionSB = new StringBuilder();
-      String prefix = "";
-      for (Integer part : this.versionParts) {
-        versionSB.append(prefix).append(part);
-        prefix = ".";
-      }
-      this.versionString = versionSB.toString();
-
-      StringBuilder normalizedSB = new StringBuilder();
-      prefix = "";
-      for (Integer part : normalized) {
-        normalizedSB.append(prefix).append(part);
-        prefix = ".";
-      }
-      this.normalizedString = normalizedSB.toString();
-
-    } catch (Exception e) {
-      throw new IllegalArgumentException(
-          "Invalid semantic version string: " + versionString);
-    }
-  }
-
-  /**
-   * Overridden to return <code>true</code> if and only if the specified parameter
-   * is a non-null reference to an object of the same class with equivalent
-   * version parts.
-   *
-   * @param object The object to compare with.
-   *
-   * @return <code>true</code> if the objects are equal, otherwise
-   *         <code>false</code>
-   */
-  @Override
-  public boolean equals(Object object) {
-    if (object == null)
-      return false;
-    if (this == object)
-      return true;
-    if (this.getClass() != object.getClass())
-      return false;
-    SemanticVersion version = (SemanticVersion) object;
-    return (this.compareTo(version) == 0);
-  }
-
-  /**
-   * Implemented to return a hash code that is consistent with the {@link
-   * #equals(Object)} implementation.
-   *
-   * @return The hash code for this instance.
-   */
-  @Override
-  public int hashCode() {
-    return this.normalizedString.hashCode();
-  }
-
-  /**
-   * Implemented to compare the parts of the semantic version in order.
-   */
-  @Override
-  public int compareTo(SemanticVersion other) {
-    Objects.requireNonNull(
-        other, "The specified parameter cannot be null");
-    Iterator<Integer> iter1 = this.versionParts.iterator();
-    Iterator<Integer> iter2 = other.versionParts.iterator();
-
-    // iterate over the parts
-    while (iter1.hasNext() || iter2.hasNext()) {
-      // get the next version parts
-      Integer part1 = iter1.hasNext() ? iter1.next() : 0;
-      Integer part2 = iter2.hasNext() ? iter2.next() : 0;
-
-      // get the diff between the parts
-      int diff = part1 - part2;
-
-      // if the diff is non-zero then return it
-      if (diff != 0)
-        return diff;
     }
 
-    // if we have exhausted all version parts without a difference then we have
-    // equality
-    return 0;
-  }
-
-  /**
-   * Returns the version string for this instance. This is equivalent to
-   * calling {@link #toString(boolean)} with <code>false</code> as the parameter.
-   *
-   * @return The version string for this instance.
-   */
-  @Override
-  public String toString() {
-    return this.toString(false);
-  }
-
-  /**
-   * Returns a version string for this instance that is optionally normalized
-   * to remove trailing zeroes.
-   *
-   * @param normalized <code>true</code> if trailing zeroes should be stripped,
-   *                   otherwise <code>false</code>.
-   *
-   * @return A {@link String} representation of this instance that is optionally
-   *         normalized to remove trailing zeroes.
-   */
-  public String toString(boolean normalized) {
-    return (normalized) ? this.normalizedString : this.versionString;
-  }
-
-  /**
-   * Provides a test main method.
-   * 
-   * @param args The command-line arguments.
-   */
-  public static void main(String[] args) {
-    if (args.length == 0) {
-      System.err.println("USAGE: java " + SemanticVersion.class.getName()
-          + " <version> [compare-version]*");
-      System.exit(1);
+    /**
+     * Builds a version string from the specified list of version parts,
+     * converting pre-release sentinel values back to their string suffixes.
+     *
+     * @param parts The list of version parts.
+     * @return The version string.
+     */
+    private static String buildVersionString(List<Integer> parts) {
+        StringBuilder sb = new StringBuilder();
+        String prefix = "";
+        for (Integer part : parts) {
+            String suffix = SUFFIX_MAP.get(part);
+            if (suffix != null) {
+                sb.append(suffix);
+                prefix = ".";
+            } else {
+                sb.append(prefix).append(part);
+                prefix = ".";
+            }
+        }
+        return sb.toString();
     }
-    SemanticVersion version = new SemanticVersion(args[0]);
-    System.out.println(
-        "VERSION: " + version + " (" + version.toString(true) + ")");
-    for (int index = 1; index < args.length; index++) {
-      SemanticVersion version2 = new SemanticVersion(args[index]);
-      System.out.println();
-      System.out.println(
-          "VERSUS " + version2 + " (" + version2.toString(true)
-              + "): "
-              + "COMPARE (" + version.compareTo(version2) + ") "
-              + " / EQUALS (" + version.equals(version2) + ") "
-              + " / HASH (" + version2.hashCode() + ") "
-              + " / HASH-EQUALITY (" + (version.hashCode() == version2.hashCode())
-              + ")");
+
+    /**
+     * Overridden to return <code>true</code> if and only if the specified parameter
+     * is a non-null reference to an object of the same class with equivalent
+     * version parts.
+     *
+     * @param object The object to compare with.
+     *
+     * @return <code>true</code> if the objects are equal, otherwise
+     *         <code>false</code>
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (object == null)
+            return false;
+        if (this == object)
+            return true;
+        if (this.getClass() != object.getClass())
+            return false;
+        SemanticVersion version = (SemanticVersion) object;
+        return (this.compareTo(version) == 0);
     }
-  }
+
+    /**
+     * Implemented to return a hash code that is consistent with the {@link
+     * #equals(Object)} implementation.
+     *
+     * @return The hash code for this instance.
+     */
+    @Override
+    public int hashCode() {
+        return this.normalizedString.hashCode();
+    }
+
+    /**
+     * Implemented to compare the parts of the semantic version in order.
+     */
+    @Override
+    public int compareTo(SemanticVersion other) {
+        Objects.requireNonNull(
+                other, "The specified parameter cannot be null");
+        Iterator<Integer> iter1 = this.versionParts.iterator();
+        Iterator<Integer> iter2 = other.versionParts.iterator();
+
+        // iterate over the parts
+        while (iter1.hasNext() || iter2.hasNext()) {
+            // get the next version parts
+            Integer part1 = iter1.hasNext() ? iter1.next() : 0;
+            Integer part2 = iter2.hasNext() ? iter2.next() : 0;
+
+            // get the diff between the parts
+            int diff = part1 - part2;
+
+            // if the diff is non-zero then return it
+            if (diff != 0)
+                return diff;
+        }
+
+        // if we have exhausted all version parts without a difference then we have
+        // equality
+        return 0;
+    }
+
+    /**
+     * Returns the version string for this instance. This is equivalent to
+     * calling {@link #toString(boolean)} with <code>false</code> as the parameter.
+     *
+     * @return The version string for this instance.
+     */
+    @Override
+    public String toString() {
+        return this.toString(false);
+    }
+
+    /**
+     * Returns a version string for this instance that is optionally normalized
+     * to remove trailing zeroes.
+     *
+     * @param normalized <code>true</code> if trailing zeroes should be stripped,
+     *                   otherwise <code>false</code>.
+     *
+     * @return A {@link String} representation of this instance that is optionally
+     *         normalized to remove trailing zeroes.
+     */
+    public String toString(boolean normalized) {
+        return (normalized) ? this.normalizedString : this.versionString;
+    }
+
+    /**
+     * Provides a test main method.
+     * 
+     * @param args The command-line arguments.
+     */
+    public static void main(String[] args) {
+        if (args.length == 0) {
+            System.err.println("USAGE: java " + SemanticVersion.class.getName()
+                    + " <version> [compare-version]*");
+            System.exit(1);
+        }
+        SemanticVersion version = new SemanticVersion(args[0]);
+        System.out.println(
+                "VERSION: " + version + " (" + version.toString(true) + ")");
+        for (int index = 1; index < args.length; index++) {
+            SemanticVersion version2 = new SemanticVersion(args[index]);
+            System.out.println();
+            System.out.println(
+                    "VERSUS " + version2 + " (" + version2.toString(true)
+                            + "): "
+                            + "COMPARE (" + version.compareTo(version2) + ") "
+                            + " / EQUALS (" + version.equals(version2) + ") "
+                            + " / HASH (" + version2.hashCode() + ") "
+                            + " / HASH-EQUALITY (" + (version.hashCode() == version2.hashCode())
+                            + ")");
+        }
+    }
 }

--- a/src/main/java/com/senzing/util/SemanticVersion.java
+++ b/src/main/java/com/senzing/util/SemanticVersion.java
@@ -77,7 +77,8 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
             this.versionParts = new ArrayList<>(tokens.length);
             boolean hasSuffix = false;
             for (String token : tokens) {
-                switch (token.toLowerCase()) {
+                String lowerToken = token.toLowerCase();
+                switch (lowerToken) {
                     case "alpha":
                     case "beta":
                     case "rc":
@@ -93,17 +94,10 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
                                     + versionString);
                         }
                         hasSuffix = true;
-                        switch (token.toLowerCase()) {
-                            case "alpha":
-                                this.versionParts.add(ALPHA_VALUE);
-                                break;
-                            case "beta":
-                                this.versionParts.add(BETA_VALUE);
-                                break;
-                            case "rc":
-                                this.versionParts.add(RC_VALUE);
-                                break;
-                        }
+                        this.versionParts.add(
+                            lowerToken.equals("alpha") ? ALPHA_VALUE
+                            : lowerToken.equals("beta") ? BETA_VALUE
+                            : RC_VALUE);
                         break;
                     default:
                         int part = Integer.parseInt(token);

--- a/src/main/java/com/senzing/util/SzUtilities.java
+++ b/src/main/java/com/senzing/util/SzUtilities.java
@@ -61,6 +61,75 @@ public class SzUtilities {
     }
 
     /**
+     * Builds bootstrap JSON settings for the Senzing environment
+     * initialization.  Bootstrap settings will allow access to the
+     * <code>SzProduct</code> functionality since that functionality
+     * does not require a database.
+     * <p>
+     * Settings will be of the form:
+     * <pre>
+     *      {
+     *          "PIPELINE": {
+     *              "SUPPORTPATH": "...",
+     *              "CONFIGPATH": "...",
+     *              "RESOURCEPATH": "..."
+     *          }
+     *      }
+     * </pre>
+     * <p>
+     * <b>NOTE:</b>
+     * This will attempt to find the Senzing installation directories on the
+     * system using Java system properties, environment variables and defaults
+     * for the operating system with the following order of precedence:
+     * <ul>
+     *  <li><code>SUPPORTPATH</code>: 
+     *      <ol>
+     *          <li><code>senzing.support.dir</code> System Property</li>
+     *          <li><code>SENZING_SUPPORT_DIR</code> Environment Variable</li>
+     *          <li><code>[senzing-path]/data</code> (see <code>[senzing-path]</code> below)</li>
+     *      </ol>
+     *  </li>
+     *  <li><code>CONFIGPATH</code>: 
+     *      <ol>
+     *          <li><code>senzing.config.dir</code> System Property</li>
+     *          <li><code>SENZING_CONFIG_DIR</code> Environment Variable</li>
+     *          <li>Linux Only: <code>/etc/opt/senzing</code> (if the directory exists)<li>
+     *          <li><code>[senzing-path]/etc</code> (see <code>[senzing-path]</code> below)</li>
+     *      </ol>
+     *  </li>
+     *  <li><code>RESOURCEPATH</code>: 
+     *      <ol>
+     *          <li><code>senzing.resource.dir</code> System Property</li>
+     *          <li><code>SENZING_RESOURCE_DIR</code> Environment Variable</li>
+     *          <li><code>[senzing-path]/resources</code> (see <code>[senzing-path]</code> below)</li>
+     *      </ol>
+     *  </li>
+     *  <li><code>[senzing-path]</code>:
+     *      <ol>
+     *          <li><code>senzing.path</code> System Property</li>
+     *          <li><code>SENZING_PATH</code> Environment Variable</li>
+     *          <li>The default directory directory for the operating system:
+     *              <ul>
+     *                  <li>Linux: <code>/opt/senzing</code></li>
+     *                  <li>macOS: <code>$HOME/senzing</code></li>
+     *                  <li>Windows: <code>%UserProfile%\senzing</code>
+     *              </ul>
+     *          </li>
+     *      </ol>
+     *  </li>
+     * </ul>
+     * 
+     * @return The bootstrap Senzing settings created using {@link 
+     *         SzInstallLocations}.
+     * 
+     * @throws IllegalStateException If the Senzing installation cannot be found.
+     */
+    public static String bootstrapSettings() throws IllegalStateException
+    {
+        return basicSettingsFromDatabaseUri(null, null, null);
+    }
+
+    /**
      * Builds basic JSON settings for the Senzing environment initialization
      * from the specified database URI for the Senzing repository.
      * <p>
@@ -71,7 +140,7 @@ public class SzUtilities {
      *              "SUPPORTPATH": "...",
      *              "CONFIGPATH": "...",
      *              "RESOURCEPATH": "..."
-     *          }
+     *          },
      *          "SQL": {
      *              "CONNECTION": "your-database-uri"
      *          }
@@ -132,6 +201,7 @@ public class SzUtilities {
     public static String basicSettingsFromDatabaseUri(String uri) 
         throws IllegalArgumentException, IllegalStateException
     {
+        Objects.requireNonNull(uri, "The database URI cannot be null");
         return basicSettingsFromDatabaseUri(uri, null, null);
     }
 
@@ -148,7 +218,7 @@ public class SzUtilities {
      *              "CONFIGPATH": "...",
      *              "RESOURCEPATH": "...",
      *              "LICENSESTRINGBASE64": "..."
-     *          }
+     *          },
      *          "SQL": {
      *              "CONNECTION": "your-database-uri"
      *          }
@@ -173,6 +243,7 @@ public class SzUtilities {
                                                       String    licenseBase64)
         throws IllegalArgumentException, IllegalStateException
     {
+        Objects.requireNonNull(uri, "The database URI cannot be null");
         return basicSettingsFromDatabaseUri(uri, licenseBase64, null);
     }
 
@@ -189,7 +260,7 @@ public class SzUtilities {
      *              "CONFIGPATH": "...",
      *              "RESOURCEPATH": "...",
      *              "LICENSEFILE": "..."
-     *          }
+     *          },
      *          "SQL": {
      *              "CONNECTION": "your-database-uri"
      *          }
@@ -213,6 +284,7 @@ public class SzUtilities {
                                                       File      licenseFile)
         throws IllegalArgumentException, IllegalStateException
     {
+        Objects.requireNonNull(uri, "The database URI cannot be null");
         return basicSettingsFromDatabaseUri(uri, null, licenseFile);
     }
     
@@ -243,10 +315,12 @@ public class SzUtilities {
                                                        File     licenseFile)
     {
         try {
-            Objects.requireNonNull(uri, "The specified URI cannot be null");
-            if (!startsWithDatabaseUriPrefix(uri)) {
-                throw new IllegalArgumentException(
-                    "The specified database URI does not appear legal: " + uri);
+            if (uri != null) {
+                if (!startsWithDatabaseUriPrefix(uri)) {
+                    throw new IllegalArgumentException(
+                        "The specified database URI does not appear to be legal: " 
+                        + uri);
+                }
             }
             if (licenseBase64 != null && licenseFile != null) {
                 throw new IllegalArgumentException(
@@ -255,7 +329,8 @@ public class SzUtilities {
 
             JsonObjectBuilder mainBuilder = Json.createObjectBuilder();
             JsonObjectBuilder pipelineBuilder = Json.createObjectBuilder();
-            JsonObjectBuilder sqlBuilder = Json.createObjectBuilder();
+            JsonObjectBuilder sqlBuilder = (uri == null) ? null
+                                                         : Json.createObjectBuilder();
             
             SzInstallLocations locations = SzInstallLocations.findLocations();
             
@@ -268,9 +343,10 @@ public class SzUtilities {
                 pipelineBuilder.add("LICENSEFILE", licenseFile.getCanonicalPath());
             }
             mainBuilder.add("PIPELINE", pipelineBuilder);
-            sqlBuilder.add("CONNECTION", uri);
-            mainBuilder.add("SQL", sqlBuilder);
-
+            if (sqlBuilder != null) {
+                sqlBuilder.add("CONNECTION", uri);
+                mainBuilder.add("SQL", sqlBuilder);
+            }
             JsonObject jsonObject = mainBuilder.build();
 
             return JsonUtilities.toJsonText(jsonObject);

--- a/src/main/java/com/senzing/util/SzUtilities.java
+++ b/src/main/java/com/senzing/util/SzUtilities.java
@@ -82,22 +82,22 @@ public class SzUtilities {
      * system using Java system properties, environment variables and defaults
      * for the operating system with the following order of precedence:
      * <ul>
-     *  <li><code>SUPPORTPATH</code>: 
+     *  <li><code>SUPPORTPATH</code>:
      *      <ol>
      *          <li><code>senzing.support.dir</code> System Property</li>
      *          <li><code>SENZING_SUPPORT_DIR</code> Environment Variable</li>
      *          <li><code>[senzing-path]/data</code> (see <code>[senzing-path]</code> below)</li>
      *      </ol>
      *  </li>
-     *  <li><code>CONFIGPATH</code>: 
+     *  <li><code>CONFIGPATH</code>:
      *      <ol>
      *          <li><code>senzing.config.dir</code> System Property</li>
      *          <li><code>SENZING_CONFIG_DIR</code> Environment Variable</li>
-     *          <li>Linux Only: <code>/etc/opt/senzing</code> (if the directory exists)<li>
+     *          <li>Linux Only: <code>/etc/opt/senzing</code> (if the directory exists)</li>
      *          <li><code>[senzing-path]/etc</code> (see <code>[senzing-path]</code> below)</li>
      *      </ol>
      *  </li>
-     *  <li><code>RESOURCEPATH</code>: 
+     *  <li><code>RESOURCEPATH</code>:
      *      <ol>
      *          <li><code>senzing.resource.dir</code> System Property</li>
      *          <li><code>SENZING_RESOURCE_DIR</code> Environment Variable</li>
@@ -108,11 +108,11 @@ public class SzUtilities {
      *      <ol>
      *          <li><code>senzing.path</code> System Property</li>
      *          <li><code>SENZING_PATH</code> Environment Variable</li>
-     *          <li>The default directory directory for the operating system:
+     *          <li>The default directory for the operating system:
      *              <ul>
      *                  <li>Linux: <code>/opt/senzing</code></li>
      *                  <li>macOS: <code>$HOME/senzing</code></li>
-     *                  <li>Windows: <code>%UserProfile%\senzing</code>
+     *                  <li>Windows: <code>%UserProfile%\senzing</code></li>
      *              </ul>
      *          </li>
      *      </ol>
@@ -152,22 +152,22 @@ public class SzUtilities {
      * system using Java system properties, environment variables and defaults
      * for the operating system with the following order of precedence:
      * <ul>
-     *  <li><code>SUPPORTPATH</code>: 
+     *  <li><code>SUPPORTPATH</code>:
      *      <ol>
      *          <li><code>senzing.support.dir</code> System Property</li>
      *          <li><code>SENZING_SUPPORT_DIR</code> Environment Variable</li>
      *          <li><code>[senzing-path]/data</code> (see <code>[senzing-path]</code> below)</li>
      *      </ol>
      *  </li>
-     *  <li><code>CONFIGPATH</code>: 
+     *  <li><code>CONFIGPATH</code>:
      *      <ol>
      *          <li><code>senzing.config.dir</code> System Property</li>
      *          <li><code>SENZING_CONFIG_DIR</code> Environment Variable</li>
-     *          <li>Linux Only: <code>/etc/opt/senzing</code> (if the directory exists)<li>
+     *          <li>Linux Only: <code>/etc/opt/senzing</code> (if the directory exists)</li>
      *          <li><code>[senzing-path]/etc</code> (see <code>[senzing-path]</code> below)</li>
      *      </ol>
      *  </li>
-     *  <li><code>RESOURCEPATH</code>: 
+     *  <li><code>RESOURCEPATH</code>:
      *      <ol>
      *          <li><code>senzing.resource.dir</code> System Property</li>
      *          <li><code>SENZING_RESOURCE_DIR</code> Environment Variable</li>
@@ -178,11 +178,11 @@ public class SzUtilities {
      *      <ol>
      *          <li><code>senzing.path</code> System Property</li>
      *          <li><code>SENZING_PATH</code> Environment Variable</li>
-     *          <li>The default directory directory for the operating system:
+     *          <li>The default directory for the operating system:
      *              <ul>
      *                  <li>Linux: <code>/opt/senzing</code></li>
      *                  <li>macOS: <code>$HOME/senzing</code></li>
-     *                  <li>Windows: <code>%UserProfile%\senzing</code>
+     *                  <li>Windows: <code>%UserProfile%\senzing</code></li>
      *              </ul>
      *          </li>
      *      </ol>
@@ -303,11 +303,13 @@ public class SzUtilities {
      *                    <code>LICENSEFILE</code> is to be excluded.
      * 
      * @return The basic Senzing settings created from the specified database URI
-     *         and base-64 encoded license string.
-     * 
-     * @throws NullPointerException If the specified URI is <code>null</code>.
-     * @throws IllegalArgumentException If the specified URI does not begin with
-     *                                  a legal prefix for a Senzing repository.
+     *         and base-64 encoded license string, or bootstrap settings if the
+     *         URI is <code>null</code>.
+     *
+     * @throws IllegalArgumentException If the specified URI is non-null and does
+     *                                  not begin with a legal prefix for a
+     *                                  Senzing repository, or if both a license
+     *                                  file and base-64 license are specified.
      * @throws IllegalStateException If the Senzing installation cannot be found.
      */
     private static String basicSettingsFromDatabaseUri(String   uri,
@@ -375,11 +377,11 @@ public class SzUtilities {
      * <ol>
      *     <li><code>senzing.path</code> System Property</li>
      *     <li><code>SENZING_PATH</code> Environment Variable</li>
-     *     <li>The default directory directory for the operating system:
+     *     <li>The default directory for the operating system:
      *         <ul>
      *             <li>Linux: <code>/opt/senzing</code></li>
      *             <li>macOS: <code>$HOME/senzing</code></li>
-     *             <li>Windows: <code>%UserProfile%\senzing</code>
+     *             <li>Windows: <code>%UserProfile%\senzing</code></li>
      *         </ul>
      *     </li>
      * </ol>

--- a/src/test/java/com/senzing/util/SemanticVersionTest.java
+++ b/src/test/java/com/senzing/util/SemanticVersionTest.java
@@ -73,6 +73,7 @@ public class SemanticVersionTest {
 
     return result;
   }
+
   @ParameterizedTest
   @MethodSource("provideEqualParams")
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/senzing/util/SemanticVersionTest.java
+++ b/src/test/java/com/senzing/util/SemanticVersionTest.java
@@ -67,6 +67,10 @@ public class SemanticVersionTest {
     result.add(arguments("2.0.0-alpha.1", "2.0.0-beta.1", false, null));
     result.add(arguments("2.0.0-rc.1", "2.0.0", false, null));
 
+    // invalid pre-release position tests
+    result.add(arguments("alpha.1.2.3", "1.0", null, illegalArg));
+    result.add(arguments("1.0.alpha.beta.2", "1.0", null, illegalArg));
+
     return result;
   }
   @ParameterizedTest
@@ -168,6 +172,10 @@ public class SemanticVersionTest {
     result.add(arguments("1.0.0-alpha", "1.0.0-alpha", null));
     result.add(arguments("3.1.0-RC.1", "3.1.0-rc.1", null));
 
+    // invalid pre-release position tests
+    result.add(arguments("alpha.1.2.3", null, illegalArg));
+    result.add(arguments("1.0.alpha.beta.2", null, illegalArg));
+
     return result;
   }
 
@@ -242,6 +250,10 @@ public class SemanticVersionTest {
     result.add(arguments("2.0.0-alpha", "2.0.0", -1, null));
     result.add(arguments("1.0.0-rc.1", "2.0.0-alpha.1", -1, null));
     result.add(arguments("2.0.0-beta.1", "2.0.0-beta.1", 0, null));
+
+    // invalid pre-release position tests
+    result.add(arguments("alpha.1.2.3", "1.0", null, illegalArg));
+    result.add(arguments("1.0.alpha.beta.2", "1.0", null, illegalArg));
 
     return result;
   }

--- a/src/test/java/com/senzing/util/SemanticVersionTest.java
+++ b/src/test/java/com/senzing/util/SemanticVersionTest.java
@@ -59,6 +59,14 @@ public class SemanticVersionTest {
     result.add(arguments("1.0", null, null, nullPointer));
     result.add(arguments("1.-1.0", "2.1.0", null, illegalArg));
 
+    // pre-release equality tests
+    result.add(arguments("2.0.0-alpha.2.0", "2.0.0-alpha.2.0", true, null));
+    result.add(arguments("2.0.0-alpha.2", "2.0.0-alpha.2.0", true, null));
+    result.add(arguments("2.0.0-beta.3.2", "2.0.0-beta.3.2", true, null));
+    result.add(arguments("2.0.0-rc.1", "2.0.0-rc.1", true, null));
+    result.add(arguments("2.0.0-alpha.1", "2.0.0-beta.1", false, null));
+    result.add(arguments("2.0.0-rc.1", "2.0.0", false, null));
+
     return result;
   }
   @ParameterizedTest
@@ -153,6 +161,13 @@ public class SemanticVersionTest {
     result.add(arguments(null,  null, nullPointer));
     result.add(arguments("1.-1.0", null, illegalArg));
 
+    // pre-release toString tests
+    result.add(arguments("2.0.0-alpha.2.0", "2.0.0-alpha.2.0", null));
+    result.add(arguments("2.0.0-beta.3.2", "2.0.0-beta.3.2", null));
+    result.add(arguments("2.0.0-rc.2.1", "2.0.0-rc.2.1", null));
+    result.add(arguments("1.0.0-alpha", "1.0.0-alpha", null));
+    result.add(arguments("3.1.0-RC.1", "3.1.0-rc.1", null));
+
     return result;
   }
 
@@ -217,6 +232,16 @@ public class SemanticVersionTest {
     result.add(arguments(null, "1.0", null, nullPointer));
     result.add(arguments("1.0", null, null, nullPointer));
     result.add(arguments("1.-1.0", "2.1.0", null, illegalArg));
+
+    // pre-release ordering tests
+    result.add(arguments("2.0.0-alpha.2.0", "2.0.0-beta.3.2", -1, null));
+    result.add(arguments("2.0.0-beta.3.2", "2.0.0-rc.2.1", -1, null));
+    result.add(arguments("2.0.0-rc.2.1", "2.0.0", -1, null));
+    result.add(arguments("2.0.0-alpha.1", "2.0.0-alpha.2", -1, null));
+    result.add(arguments("2.0.0-rc.1", "2.0.0-rc.2", -1, null));
+    result.add(arguments("2.0.0-alpha", "2.0.0", -1, null));
+    result.add(arguments("1.0.0-rc.1", "2.0.0-alpha.1", -1, null));
+    result.add(arguments("2.0.0-beta.1", "2.0.0-beta.1", 0, null));
 
     return result;
   }


### PR DESCRIPTION
Resolves Issue #202 

- Added `SzUtilities.bootstrapSettings()` method to build bootstrap JSON
  settings for Senzing environment initialization without requiring a
  database URI, enabling access to `SzProduct` functionality.
- Added null-checks to existing `SzUtilities.basicSettingsFromDatabaseUri()`
  overloads to fail fast on null URI parameters.
- Fixed trailing comma in JSON example in `SzUtilities` javadoc.
- Added pre-release suffix support to `SemanticVersion` for parsing and
  comparing versions with `-alpha`, `-beta`, and `-rc` suffixes (e.g.:
  `"2.0.0-alpha.2.0"`, `"2.0.0-beta.3.2"`, `"2.0.0-rc.2.1"`).
  Pre-release suffixes are normalized to lowercase.

---

Resolves #202
Resolves #203