### PR TITLE
Silence test-run noise from system-stubs and capture-pattern docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -172,6 +172,38 @@ Tests use JUnit Jupiter 6 with parallel execution enabled:
 - Dynamic parallelism factor (1x number of cores)
 - System property `project.build.directory` available in tests
 
+#### System Stubs, ExecutionMode, and ResourceLock
+
+Tests that **stub environment variables** or **capture stdout / stderr**
+must follow the project's `system-stubs` +
+`@Execution(SAME_THREAD)` + `@ResourceLock` pattern to avoid
+build-log noise and inter-class capture races. Before writing such a
+test, search the FAQ:
+`mcp__senzing-commons-faq__search_faqs(query="system stubs")`.
+
+Headline rules:
+
+- Use `system-stubs-jupiter` **programmatically at the method level**
+  (`new EnvironmentVariables(...).execute(...)`, `new SystemOut()
+  .execute(...)`, `new SystemErr().execute(...)`) — never the
+  `@ExtendWith` annotation form.
+- Tag the test (or the class) with
+  `@Execution(ExecutionMode.SAME_THREAD)` — `System.setOut` /
+  `setErr` are JVM-wide, so concurrent redirects race.
+- Add `@ResourceLock(Resources.SYSTEM_OUT)` and/or
+  `@ResourceLock(Resources.SYSTEM_ERR)` for cross-class mutual
+  exclusion. When both are present, **always declare
+  `SYSTEM_OUT` first, `SYSTEM_ERR` second** to avoid deadlock.
+- `LoggingUtilities.logDebug` writes to **`System.out`** (not
+  stderr); use `SystemOut` to capture it.
+- If the production code starts a background thread in its
+  constructor, place the `new ...()` call **inside** the
+  `stub.execute(...)` lambda so the redirect is active before the
+  thread starts.
+
+Full pattern, examples, and the JVM-warning suppression details
+are in the `testing/system-stubs-and-output-capture` FAQ.
+
 ## Development Notes
 
 ### Java and Maven Versions

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -46,7 +46,7 @@ push operational/troubleshooting depth into FAQ files.
 
 Senzing Commons Java Library is a collection of reusable Java utilities, interfaces, and classes common to multiple Senzing projects. Originally refactored from senzing-api-server, this library provides foundational components for command-line parsing, database connection pooling, I/O operations, reflection utilities, and more.
 
-The current version is `4.0.0-beta.3.0` (a beta line — see `CHANGELOG.md` for the per-release history).
+The current version is `4.0.0` (see `CHANGELOG.md` for the per-release history).
 
 ## Build and Test Commands
 

--- a/.claude/faqs/testing/system-stubs-and-output-capture.md
+++ b/.claude/faqs/testing/system-stubs-and-output-capture.md
@@ -1,4 +1,4 @@
-## System Stubs, ExecutionMode, and ResourceLock — the project pattern
+# System Stubs, ExecutionMode, and ResourceLock — the project pattern
 
 The project uses
 [`uk.org.webcompere:system-stubs-jupiter`](https://github.com/webcompere/system-stubs)
@@ -14,7 +14,7 @@ There is a specific pattern that **every** test using these stubs must
 follow. Deviating from it causes either flaky inter-class races or
 output leakage in the build log.
 
-### The pattern
+## The pattern
 
 ```java
 import org.junit.jupiter.api.parallel.Execution;
@@ -46,7 +46,7 @@ public void someTest() throws Exception
 
 Three rules in this pattern, all required:
 
-#### 1. Programmatic, at method level — not annotation-driven
+### 1. Programmatic, at method level — not annotation-driven
 
 Use `new EnvironmentVariables(...).execute(...)` and
 `new SystemOut().execute(...)` / `new SystemErr().execute(...)`
@@ -59,14 +59,14 @@ with parallel test execution, and makes it harder to scope the stub
 to just the lines that need it. Method-level execute-with-callable
 keeps the scope explicit and test-local.
 
-#### 2. `@Execution(ExecutionMode.SAME_THREAD)` on the test (or class)
+### 2. `@Execution(ExecutionMode.SAME_THREAD)` on the test (or class)
 
 `System.setOut` / `System.setErr` are JVM-wide. If two test methods
 in the same class redirect concurrently, their captured output races.
 `SAME_THREAD` keeps the test from running concurrently with siblings
 in the same class.
 
-#### 3. `@ResourceLock` for cross-class mutual exclusion
+### 3. `@ResourceLock` for cross-class mutual exclusion
 
 Add `@ResourceLock(Resources.SYSTEM_OUT)` and/or
 `@ResourceLock(Resources.SYSTEM_ERR)` on the test (or class) to
@@ -85,7 +85,7 @@ Use the lock matching what the test redirects:
 - `SystemErr.execute(...)` → `@ResourceLock(Resources.SYSTEM_ERR)`
 - Both → both locks (see ordering rule below)
 
-### Lock ordering convention — avoid deadlocks
+## Lock ordering convention — avoid deadlocks
 
 When a test holds **both** `SYSTEM_OUT` and `SYSTEM_ERR` locks, declare
 them in this canonical order:
@@ -102,7 +102,7 @@ waiting for `OUT`. The project convention is **always
 `SYSTEM_OUT` first, `SYSTEM_ERR` second**, which makes deadlock
 impossible.
 
-### Class-level vs. method-level locking
+## Class-level vs. method-level locking
 
 - **Class-level locks** make sense when **most** tests in the class
   redirect (e.g. `LoggingUtilitiesTest`, `SQLUtilitiesTest`,
@@ -117,9 +117,9 @@ impossible.
   the class would needlessly serialize against unrelated tests in
   other classes.
 
-### Gotchas
+## Gotchas
 
-#### Wrap the **right** stream
+### Wrap the **right** stream
 
 `LoggingUtilities.logDebug(...)` writes to **`System.out`** (despite
 the word "log" suggesting stderr). Tests that exercise debug-logging
@@ -136,7 +136,7 @@ whether the production code writes to `out` vs `err`:
 - `printStackTrace()` (no args) → `System.err`
 - `Throwable.printStackTrace(System.out)` → `System.out`
 
-#### Background-thread output: wrap the construction call too
+### Background-thread output: wrap the construction call too
 
 If the production code starts a background thread inside its
 constructor (e.g. `TemporaryDataCache` starts a `ConsumerThread` that
@@ -169,7 +169,7 @@ new SystemErr().execute(() -> {
 });
 ```
 
-#### JVM warnings about byte-buddy
+### JVM warnings about byte-buddy
 
 `system-stubs-jupiter` transitively pulls in `byte-buddy-agent` so it
 can dynamically attach as a Java agent and modify JDK-internal fields
@@ -192,7 +192,7 @@ JaCoCo agent flags via the `argLine` property when running under
 producing a final argument list with the JaCoCo flags followed by
 `-XX:+EnableDynamicAgentLoading -Xshare:off`.
 
-### Tests that don't use system-stubs
+## Tests that don't use system-stubs
 
 A small number of older tests redirect `System.out` / `System.err`
 with raw `System.setOut(new PrintStream(baos))` plus a try/finally
@@ -214,7 +214,7 @@ If a test only needs to verify a method **doesn't throw**, capture
 is unnecessary — but wrapping with `SystemOut` / `SystemErr` is
 still cheap and keeps the build log clean.
 
-### Examples in this codebase
+## Examples in this codebase
 
 - `CommandLineUtilitiesEnvTest` — `EnvironmentVariables.execute`,
   class-level `@Execution(SAME_THREAD)`.

--- a/.claude/faqs/testing/system-stubs-and-output-capture.md
+++ b/.claude/faqs/testing/system-stubs-and-output-capture.md
@@ -1,0 +1,234 @@
+## System Stubs, ExecutionMode, and ResourceLock — the project pattern
+
+The project uses
+[`uk.org.webcompere:system-stubs-jupiter`](https://github.com/webcompere/system-stubs)
+(test scope, declared in `pom.xml`) to:
+
+- Stub environment variables that production code reads via
+  `System.getenv(...)`, since `getenv()` is unmodifiable on JDK 17+.
+- Capture `System.out` / `System.err` for tests that exercise
+  expected-error paths so the captured output does not pollute the
+  build log.
+
+There is a specific pattern that **every** test using these stubs must
+follow. Deviating from it causes either flaky inter-class races or
+output leakage in the build log.
+
+### The pattern
+
+```java
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
+
+@Test
+@Execution(ExecutionMode.SAME_THREAD)
+@ResourceLock(Resources.SYSTEM_OUT)
+@ResourceLock(Resources.SYSTEM_ERR)
+public void someTest() throws Exception
+{
+  // Programmatic at method level — never via @ExtendWith.
+  new EnvironmentVariables("MY_VAR", "value").execute(() -> {
+    // code under test runs with the env var set
+  });
+
+  SystemErr stub = new SystemErr();
+  stub.execute(() -> {
+    // code under test; stderr is captured during this lambda
+  });
+  String captured = stub.getText();
+}
+```
+
+Three rules in this pattern, all required:
+
+#### 1. Programmatic, at method level — not annotation-driven
+
+Use `new EnvironmentVariables(...).execute(...)` and
+`new SystemOut().execute(...)` / `new SystemErr().execute(...)`
+**inside** the test method. **Never** the
+`@ExtendWith(SystemStubsExtension.class)` + `@SystemStub` annotation
+form.
+
+The annotation form applies the stub class-wide, interacts poorly
+with parallel test execution, and makes it harder to scope the stub
+to just the lines that need it. Method-level execute-with-callable
+keeps the scope explicit and test-local.
+
+#### 2. `@Execution(ExecutionMode.SAME_THREAD)` on the test (or class)
+
+`System.setOut` / `System.setErr` are JVM-wide. If two test methods
+in the same class redirect concurrently, their captured output races.
+`SAME_THREAD` keeps the test from running concurrently with siblings
+in the same class.
+
+#### 3. `@ResourceLock` for cross-class mutual exclusion
+
+Add `@ResourceLock(Resources.SYSTEM_OUT)` and/or
+`@ResourceLock(Resources.SYSTEM_ERR)` on the test (or class) to
+serialize against other classes that also redirect those streams.
+
+`SAME_THREAD` only orders execution **within** a single test class.
+Two tests in **different** classes that each redirect stderr can
+still run concurrently and clobber each other's capture. JUnit's
+`@ResourceLock(Resources.SYSTEM_OUT)` and
+`@ResourceLock(Resources.SYSTEM_ERR)` provide the cross-class
+mutex.
+
+Use the lock matching what the test redirects:
+
+- `SystemOut.execute(...)` → `@ResourceLock(Resources.SYSTEM_OUT)`
+- `SystemErr.execute(...)` → `@ResourceLock(Resources.SYSTEM_ERR)`
+- Both → both locks (see ordering rule below)
+
+### Lock ordering convention — avoid deadlocks
+
+When a test holds **both** `SYSTEM_OUT` and `SYSTEM_ERR` locks, declare
+them in this canonical order:
+
+```java
+@ResourceLock(Resources.SYSTEM_OUT)
+@ResourceLock(Resources.SYSTEM_ERR)
+```
+
+JUnit acquires resource locks in declaration order. If test A declares
+`OUT` then `ERR` and test B declares `ERR` then `OUT`, two parallel
+runs can deadlock: A holds `OUT` waiting for `ERR`, B holds `ERR`
+waiting for `OUT`. The project convention is **always
+`SYSTEM_OUT` first, `SYSTEM_ERR` second**, which makes deadlock
+impossible.
+
+### Class-level vs. method-level locking
+
+- **Class-level locks** make sense when **most** tests in the class
+  redirect (e.g. `LoggingUtilitiesTest`, `SQLUtilitiesTest`,
+  `SzInstallLocationsTest`). Annotate the class with
+  `@Execution(SAME_THREAD)` + the relevant `@ResourceLock(...)`
+  annotations.
+- **Method-level locks** are right when only one or two tests in the
+  class redirect (e.g. `RecordReaderExtraTest.mainPrintsRecords...`,
+  `CommandLineUtilitiesExtraTest.mainDoesNotThrow`). Annotate the
+  individual methods with `@Execution(SAME_THREAD)` and
+  `@ResourceLock(...)`. Don't class-lock; non-redirecting tests in
+  the class would needlessly serialize against unrelated tests in
+  other classes.
+
+### Gotchas
+
+#### Wrap the **right** stream
+
+`LoggingUtilities.logDebug(...)` writes to **`System.out`** (despite
+the word "log" suggesting stderr). Tests that exercise debug-logging
+paths must wrap with `SystemOut`, not `SystemErr`. The
+`TemporaryDataCacheExtraTest.attachStreamDebugLoggingBranchEnabled`
+test originally used `SystemErr` and the debug output leaked to the
+build log because of this.
+
+In general, when a test fails to capture output, double-check
+whether the production code writes to `out` vs `err`:
+
+- `LoggingUtilities.logInfo` / `logDebug` → `System.out`
+- `LoggingUtilities.logError` / `logWarning` → `System.err`
+- `printStackTrace()` (no args) → `System.err`
+- `Throwable.printStackTrace(System.out)` → `System.out`
+
+#### Background-thread output: wrap the construction call too
+
+If the production code starts a background thread inside its
+constructor (e.g. `TemporaryDataCache` starts a `ConsumerThread` that
+consumes the source `InputStream`), that thread can throw and the
+JVM's default uncaught-exception handler prints its stack trace to
+`System.err` — **outside** the test's redirect window if the
+constructor ran before `stub.execute(...)`.
+
+The fix is to move the construction call **inside** the
+`stub.execute(...)` lambda so the redirect is active before the
+background thread starts:
+
+```java
+// WRONG — consumer thread starts and may throw before stub redirects:
+TemporaryDataCache tdc = new TemporaryDataCache(failingSource);
+new SystemErr().execute(() -> {
+  tdc.waitUntilAppendingComplete();
+  ...
+});
+
+// RIGHT — construction is inside the redirect window:
+new SystemErr().execute(() -> {
+  TemporaryDataCache tdc = new TemporaryDataCache(failingSource);
+  try {
+    tdc.waitUntilAppendingComplete();
+    ...
+  } finally {
+    tdc.delete();
+  }
+});
+```
+
+#### JVM warnings about byte-buddy
+
+`system-stubs-jupiter` transitively pulls in `byte-buddy-agent` so it
+can dynamically attach as a Java agent and modify JDK-internal fields
+(needed for `EnvironmentVariables` to mutate
+`ProcessEnvironment.theEnvironment`). On JDK 21+ that triggers a
+"Java agent loaded dynamically" warning, plus
+"Sharing is only supported for boot loader classes" on some JDKs.
+
+The `pom.xml` surefire plugin is configured with:
+
+```xml
+<argLine>@{argLine} -XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
+```
+
+which silences both. The `@{argLine}` late-bound reference (paired
+with an empty `<argLine>` property declared at the top of `pom.xml`)
+lets the `jacoco` profile's `prepare-agent` still supply its
+JaCoCo agent flags via the `argLine` property when running under
+`-Pjacoco`. Surefire then evaluates `@{argLine}` at fork time,
+producing a final argument list with the JaCoCo flags followed by
+`-XX:+EnableDynamicAgentLoading -Xshare:off`.
+
+### Tests that don't use system-stubs
+
+A small number of older tests redirect `System.out` / `System.err`
+with raw `System.setOut(new PrintStream(baos))` plus a try/finally
+restore (e.g.
+`ZipUtilitiesTest.mainWithMultipleTextArgsIteratesAllArguments`).
+That style predates system-stubs, is fine to leave alone for
+fully-synchronous redirects, and avoids the byte-buddy dependency
+on a per-test basis. **All other rules above still apply** —
+`@Execution(SAME_THREAD)` and the appropriate `@ResourceLock`
+annotations are mandatory because they protect against concurrent
+JVM-wide stream redirects regardless of which redirect mechanism is
+used.
+
+When **adding** a new test, prefer system-stubs over raw
+`setOut`/`setErr` for consistency with the rest of the codebase.
+Raw redirection is grandfathered, not recommended.
+
+If a test only needs to verify a method **doesn't throw**, capture
+is unnecessary — but wrapping with `SystemOut` / `SystemErr` is
+still cheap and keeps the build log clean.
+
+### Examples in this codebase
+
+- `CommandLineUtilitiesEnvTest` — `EnvironmentVariables.execute`,
+  class-level `@Execution(SAME_THREAD)`.
+- `CommandLineUtilitiesFallbackTest` — env-var fallback resolution.
+- `LoggingUtilitiesTest`, `SQLUtilitiesTest` — class-level
+  `@ResourceLock(SYSTEM_OUT)` + `@ResourceLock(SYSTEM_ERR)`.
+- `SzInstallLocationsTest` — class-level `@ResourceLock(SYSTEM_ERR)`,
+  per-method `new SystemErr().execute(...)` for the four
+  exception-path tests that print stack traces.
+- `TemporaryDataCacheExtraTest.attachStreamDebugLoggingBranchEnabled`
+  — `SystemOut` (debug output goes to stdout).
+- `TemporaryDataCacheExtraTest.failureInSourceStreamSurfacesToReader`
+  — illustrates the background-thread gotcha; the cache constructor
+  is inside the `SystemErr.execute(...)` lambda.
+- `WorkerThreadPoolExtraTest.mainExecutesArgumentsAndPrintsOutput`
+  — both `SystemOut` and `SystemErr`, with locks declared in
+  canonical order.

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -44,6 +44,7 @@
     "Pcheckstyle",
     "phoo",
     "PKCS",
+    "Pjacoco",
     "prefs",
     "PRNG",
     "pushback",
@@ -65,8 +66,9 @@
     "szcore",
     "Unsynchronized",
     "webcompere",
-    "Xlint",
     "xerial",
+    "Xlint",
+    "Xshare",
     "Zonky"
   ],
   "ignorePaths": [

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <junit.jupiter.version>5.13.4</junit.jupiter.version>
     <buildDirectory>${project.basedir}/target</buildDirectory>
+    <!-- Declared empty so the surefire `<argLine>@{argLine} ...</argLine>`
+         late-bound reference always resolves. The jacoco profile's
+         prepare-agent goal overwrites this with the JaCoCo agent
+         flags during tests run under -Pjacoco. -->
+    <argLine></argLine>
   </properties>
   <build>
     <directory>${buildDirectory}</directory>
@@ -132,6 +137,16 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.5</version>
         <configuration>
+          <!-- -XX:+EnableDynamicAgentLoading silences the JVM warning
+               emitted when system-stubs-jupiter dynamically attaches
+               its byte-buddy agent at test time. -Xshare:off avoids
+               the "Sharing is only supported for boot loader classes"
+               warning that appears alongside it on some JDKs when the
+               bootstrap classpath is appended. The @{argLine}
+               late-bound reference lets the jacoco profile's
+               prepare-agent contribution be prepended without being
+               overwritten. -->
+          <argLine>@{argLine} -XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
           </systemPropertyVariables>

--- a/src/test/java/com/senzing/io/TemporaryDataCacheExtraTest.java
+++ b/src/test/java/com/senzing/io/TemporaryDataCacheExtraTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 import uk.org.webcompere.systemstubs.stream.SystemErr;
+import uk.org.webcompere.systemstubs.stream.SystemOut;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -165,14 +166,15 @@ public class TemporaryDataCacheExtraTest
    * {@code logDebug}. Wrapping the test in a thread-local
    * debug-logging override exercises that branch.
    *
-   * <p>Captures {@link System#err} since {@code logDebug} writes
-   * there, and tags {@link Execution} {@code SAME_THREAD} +
-   * {@link ResourceLock} for the global stderr to keep the build
+   * <p>{@link LoggingUtilities#logDebug} writes to
+   * {@link System#out}, so a {@link SystemOut} stub captures the
+   * output. Tagged {@link Execution} {@code SAME_THREAD} +
+   * {@link ResourceLock} for the global stdout to keep the build
    * log clean and avoid races with concurrent tests.</p>
    */
   @Test
   @Execution(ExecutionMode.SAME_THREAD)
-  @ResourceLock(Resources.SYSTEM_ERR)
+  @ResourceLock(Resources.SYSTEM_OUT)
   public void attachStreamDebugLoggingBranchEnabled()
       throws Exception
   {
@@ -184,7 +186,7 @@ public class TemporaryDataCacheExtraTest
       try {
         tdc.waitUntilAppendingComplete();
 
-        SystemErr stub = new SystemErr();
+        SystemOut stub = new SystemOut();
         stub.execute(() -> {
           InputStream is = tdc.getInputStream();
           try {
@@ -328,8 +330,20 @@ public class TemporaryDataCacheExtraTest
    * If the source {@link InputStream} throws on read, the consumer
    * thread must record the failure via {@code setFailure}, and the
    * next reader-side method must rethrow it via {@code checkFailure}.
+   *
+   * <p>The {@code ConsumerThread} rethrows the wrapped
+   * {@link RuntimeException} after recording the failure, which the
+   * JVM's default uncaught-exception handler then prints to
+   * {@link System#err}. The whole test runs inside a
+   * {@link SystemErr} stub so the simulated failure's stack trace
+   * does not pollute the build log. Tagged
+   * {@link Execution} {@code SAME_THREAD} +
+   * {@link ResourceLock} on stderr to avoid races with concurrent
+   * tests.</p>
    */
   @Test
+  @Execution(ExecutionMode.SAME_THREAD)
+  @ResourceLock(Resources.SYSTEM_ERR)
   public void failureInSourceStreamSurfacesToReader() throws Exception
   {
     InputStream failing = new InputStream()
@@ -346,21 +360,26 @@ public class TemporaryDataCacheExtraTest
       }
     };
 
-    TemporaryDataCache tdc = new TemporaryDataCache(failing);
-    try {
-      // Wait for consumer thread to encounter the failure.
-      tdc.waitUntilAppendingComplete();
+    new SystemErr().execute(() -> {
+      TemporaryDataCache tdc = new TemporaryDataCache(failing);
+      try {
+        // Wait for consumer thread to encounter the failure. The
+        // wait is inside the stub so the consumer thread's uncaught
+        // RuntimeException stack trace, printed by the JVM's default
+        // handler, is captured rather than leaked to the build log.
+        tdc.waitUntilAppendingComplete();
 
-      // Reading must surface the failure as a RuntimeException
-      // wrapping the IOException (per setFailure / checkFailure).
-      assertThrows(RuntimeException.class, () -> {
-        try (InputStream is = tdc.getInputStream()) {
-          drain(is);
-        }
-      });
-    } finally {
-      tdc.delete();
-    }
+        // Reading must surface the failure as a RuntimeException
+        // wrapping the IOException (per setFailure / checkFailure).
+        assertThrows(RuntimeException.class, () -> {
+          try (InputStream is = tdc.getInputStream()) {
+            drain(is);
+          }
+        });
+      } finally {
+        tdc.delete();
+      }
+    });
   }
 
   // -------------------------------------------------------------------

--- a/src/test/java/com/senzing/io/TemporaryDataCacheExtraTest.java
+++ b/src/test/java/com/senzing/io/TemporaryDataCacheExtraTest.java
@@ -181,27 +181,26 @@ public class TemporaryDataCacheExtraTest
     LoggingUtilities.overrideDebugLogging(true);
     try {
       byte[] data = largeBytes();
-      TemporaryDataCache tdc = new TemporaryDataCache(
-          new ByteArrayInputStream(data));
-      try {
-        tdc.waitUntilAppendingComplete();
 
-        SystemOut stub = new SystemOut();
-        stub.execute(() -> {
+      // Construct the cache and consume it inside the SystemOut stub
+      // — the consumer thread starts in the constructor and emits
+      // debug logging during consumption, so the redirect must be
+      // active before the constructor runs.
+      new SystemOut().execute(() -> {
+        TemporaryDataCache tdc = new TemporaryDataCache(
+            new ByteArrayInputStream(data));
+        try {
+          tdc.waitUntilAppendingComplete();
           InputStream is = tdc.getInputStream();
           try {
             drain(is);
           } finally {
             is.close();
           }
-        });
-
-        // We do not need to validate exact debug text; reaching here
-        // means the debug-logging branch ran without throwing.
-        assertTrue(true);
-      } finally {
-        tdc.delete();
-      }
+        } finally {
+          tdc.delete();
+        }
+      });
     } finally {
       LoggingUtilities.clearDebugOverride();
     }

--- a/src/test/java/com/senzing/io/TemporaryDataCacheExtraTest.java
+++ b/src/test/java/com/senzing/io/TemporaryDataCacheExtraTest.java
@@ -343,7 +343,8 @@ public class TemporaryDataCacheExtraTest
   @Test
   @Execution(ExecutionMode.SAME_THREAD)
   @ResourceLock(Resources.SYSTEM_ERR)
-  public void failureInSourceStreamSurfacesToReader() throws Exception
+  public void failureInSourceStreamSurfacesToReader()
+      throws Exception
   {
     InputStream failing = new InputStream()
     {


### PR DESCRIPTION
Two distinct issues addressed together because they touch the same test wiring:

1. Test build-log was leaking output that should have been captured

`TemporaryDataCacheExtraTest.attachStreamDebugLoggingBranchEnabled` was wrapping the read in `new SystemErr().execute(...)`, but `LoggingUtilities.logDebug` writes to `System.out`, not `System.err`, so the per-file-part `PREVIEW` / `CONTENTS` dumps from `ChainFileInputStream.attachStream` printed straight through to the build log. Switched the test to `new SystemOut().execute(...)` and the matching `@ResourceLock(Resources.SYSTEM_OUT)`.

`TemporaryDataCacheExtraTest.failureInSourceStreamSurfacesToReader` wrapped only the reader-side `assertThrows` in `SystemErr.execute`, but the source stream is consumed by a background `ConsumerThread` that is started in the `TemporaryDataCache(...)` constructor. When that thread caught the simulated `IOException` and rethrew it as a `RuntimeException`, the JVM's default uncaught-exception handler printed the stack trace to `System.err` *before* the test entered its stub. Moved the constructor and `waitUntilAppendingComplete()` call **inside** the `SystemErr.execute(...)` lambda, and tagged the test with `@Execution(SAME_THREAD)` + `@ResourceLock(SYSTEM_ERR)` so the redirect is active throughout the consumer thread's lifetime.

2. JVM warnings from system-stubs / byte-buddy

`system-stubs-jupiter` transitively pulls in `byte-buddy-agent`, which dynamically attaches as a Java agent so it can mutate JDK-internal fields (e.g. `ProcessEnvironment.theEnvironment`, needed by `EnvironmentVariables.execute(...)`). On JDK 21+ this emits two unavoidable warnings on every JVM startup:

  WARNING: A Java agent has been loaded dynamically (...byte-buddy-agent...)
  OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot
                                    loader classes because bootstrap
                                    classpath has been appended

These can't be silenced from within Java — they're emitted by the JVM itself. Configured the surefire plugin's `<argLine>` to include `-XX:+EnableDynamicAgentLoading -Xshare:off`, which silences both at JVM startup. Used the late-bound `@{argLine}` reference so the `jacoco` profile's `prepare-agent` agent flags are still prepended when running under `-Pjacoco`. Declared an empty `<argLine>` property at the top of the POM so the late-bound reference always resolves (without `-Pjacoco` the property is empty, with it the JaCoCo agent flags are injected).

3. Knowledge capture so future tests follow the pattern

Added `.claude/faqs/testing/system-stubs-and-output-capture.md` documenting:

- The programmatic, method-level usage style (never `@ExtendWith`).
- The required `@Execution(ExecutionMode.SAME_THREAD)` tagging.
- The `@ResourceLock(Resources.SYSTEM_OUT)` / `@ResourceLock(Resources.SYSTEM_ERR)` annotations for cross-class mutual exclusion (`SAME_THREAD` only orders within a class).
- The canonical lock declaration order: **always `SYSTEM_OUT` first, then `SYSTEM_ERR`** when both are present, to prevent deadlock between two tests that hold both locks.
- Class-level vs method-level lock scoping trade-offs.
- The `LoggingUtilities.logDebug` writes-to-stdout gotcha that bit the debug-logging test.
- The background-thread gotcha: when production code starts threads in its constructor, the constructor itself must be inside the `stub.execute(...)` lambda or the thread can throw before the redirect is active.
- The byte-buddy / class-data-sharing JVM warning suppression and the `@{argLine}` interaction with the `jacoco` profile.
- An inventory of existing tests that exemplify each variant (`CommandLineUtilitiesEnvTest` for env vars, `LoggingUtilitiesTest` / `SQLUtilitiesTest` for class-level locks, `SzInstallLocationsTest` for class-level + per-method `SystemErr.execute`, `TemporaryDataCacheExtraTest` for the two gotchas, and `WorkerThreadPoolExtraTest` for combined stdout+stderr capture).

Added a corresponding pointer subsection to `.claude/CLAUDE.md` under "Testing Configuration" with the headline rules and a `mcp__senzing-commons-faq__search_faqs(query="system stubs")` search hint, so future sessions pick up the convention without reading the full FAQ first.

Verification:

- `mvn test` — 2,150 / 2,150 pass; no `PREVIEW` / `CONTENTS` / `simulated source failure` / byte-buddy / class-data-sharing output in the log.
- `mvn -Pjacoco test` — coverage still at 91.4% lines / 83.4% branches.
- `mvn -Pcheckstyle validate` — BUILD SUCCESS.
